### PR TITLE
Allice

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,9 @@ const token = config.token;
 const clientID = config.clientid;
 const prefix = "!"
 const normalChat = config.chat;
-const userRoleID = "367789057352400908"
+const userRoleID = config.userrole;
 const evalPerm = config.evalAllowed;
-const owner = "322727506736185346"
-const streamingGame = "CombineControl"
-const streamingLink = config.streamingLink;
+const owner = config.ownerid;
 const colors = config.possibleCaptchaColors;
 const blockedAccountIDs = config.blockedIDs;
 const query = require("./src/Query.json")
@@ -23,16 +21,20 @@ client.on("guildMemberAdd", (member) => {
     member.user.send({
         embed: {
             color: 0xffff00,
-            description: "To verify yourself as a human, write `" + prefix + "receive` in the guild to receive your captcha"
+            description: "To verify yourself as a human, write `" + prefix + "receive` in the #verify channel to receive your captcha via Direct Message"
         }
     });
 });
 
 
-client.on("ready", () => {
-    console.log("Logged in!")
-    client.user.setGame(streamingGame, streamingLink);
+client.on('ready', () => {
+  console.log(config.botStarted + ` ${client.user.tag}!`);
+  client.user.setPresence({ status: 'online', game: { name: config.gameMessage } }); 
+  if(config.setNewAvatar){
+    client.user.setAvatar(config.avatar); 
+  } 
 });
+
 
 client.on('message', (message) => {
     if (!message.guild) return;
@@ -108,7 +110,7 @@ client.on('message', (message) => {
                     message.author.send({
                         embed: {
                             color: 0x0000ff,
-                            description: "Write `!verify` <code> in the guild to write in all channel. \n\n**Verification Bot modified by Shekelstein#8863**"
+                            description: "\n**Please memorise the Captha <code> below!** \nReturn to #verify channel. \nWrite `!verify` <code> in the #verify channel \nto see the protected server channels."
                         }
                     });
                     message.delete();

--- a/index.js
+++ b/index.js
@@ -118,11 +118,8 @@ client.on('message', (message) => {
                     queryFile.query[author + "x" + captcha] = {
                         verified: "false"
                     };
-                    fs.writeFile("./src/Query.json", JSON.stringify(queryFile));
+                    fs.writeFile("./src/Query.json", JSON.stringify(queryFile), (error) => { console.log ("Error=" + (error)); });
                     queue.push(author + "x" + captcha);
-
-
-
 
                     waitingQueue.push(message.author.id);
                     console.log(queue);
@@ -152,11 +149,11 @@ client.on('message', (message) => {
                             description: "Successfully verified on `" + message.guild.name + "`"
                         }
                     });
-                    client.channels.find('name', normalChat).send("<@" + message.author.id + "> was successfully verified.");
+                    client.channels.find(channel => channel.name == normalChat).send("<@" + message.author.id + "> was successfully verified.");
                     queryFile.query[message.author.id + "x" + oldcaptcha].verified = "true";
                     queue.pop();
                     fs.appendFileSync("./verify_logs.txt", "[VerifyBot] " + time.getHours() + ":" + time.getMinutes() + ":" + time.getSeconds() + "| " + message.author.tag + "(" + message.author.id + ") verified himself.\n");
-                    message.member.addRole(userRoleID).catch(error => console.log(error));
+                    message.member.addRoles(userRoleID).catch(error => console.log(error));
                 }
 
             } else {

--- a/src/config.json
+++ b/src/config.json
@@ -1,11 +1,12 @@
 {  
-    "token":"Mzc3MDUwNTMwNDkwNDgyNjg5.DOHTkw.O_85jYRgyBFKsC-KgjCZScHymt8",
-    "clientid":"377050530490482689",
+    "token":"BOT_Token_goes_here",
+    "clientid":"BOT_client_ID_number_goes_here",
     "prefix":"!",
     "chat":"verify",
-    "userrole":"377062274336030720",
-    "streamingGame":"CombineControl",
-    "streamingLink":"",
+    "userrole":"user_role_ID_numer_before_verification-usually_@everyone",
+    "gameMessage":"Catching SPAM bots",
+    "botStarted": "Bot started and online as",
+    "avatar":"./avatar.png",
     "evalAllowed":"false",
     "ownerid":"322727506736185346",
     "possibleCaptchaColors":[  


### PR DESCRIPTION
Deprecation warnings are gone under NodeJS  v8.17.0. No errors during tests in live Discord server.

Thought , as much as I understand, it is better to block already verified users from writing in "verification" channel as user ID gets written multiple times in Query.json if user fails to register from the first time, gets kicked and re-joins, starts verification process again. In this case - after user gets finally verified, receives a new role and types a `!verify` command again in "verification" channel - he can loop this process to infinity, with each loop inflating Query.json file.